### PR TITLE
feat: Add Spanish Sidebar Configuration for "Becoming a Maintainer" Course (sidebar.js)

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -64,6 +64,30 @@ const sidebars = {
         ],
       },
     ],
+
+    becomingAMaintainerES: [
+      {
+        type: 'category',
+        label: 'Conviértete en mantenedor',
+        items: [
+          'becoming-a-maintainer/translations/es/README',
+          'becoming-a-maintainer/translations/es/introduccion',
+          'becoming-a-maintainer/translations/es/como-configurar-tu-proyecto',
+          'becoming-a-maintainer/translations/es/problemas-y-solicitudes-de-extraccion',
+          'becoming-a-maintainer/translations/es/comunicacion-y-colaboracion',
+          'becoming-a-maintainer/translations/es/manteniendo-la-calidad-del-codigo',
+          'becoming-a-maintainer/translations/es/construyendo-comunidad',
+          'becoming-a-maintainer/translations/es/potenciadores-para-mantenedores',
+          'becoming-a-maintainer/translations/es/tu-equipo',
+          'becoming-a-maintainer/translations/es/metricas-y-analisis',
+          'becoming-a-maintainer/translations/es/ponerse-practico',
+          'becoming-a-maintainer/translations/es/libro-de-visitas-de-mantenedores',
+          'becoming-a-maintainer/translations/es/recursos-adicionales',
+          'becoming-a-maintainer/translations/es/glosario',
+        ],
+      },
+    ],
   };
   
+
   export default sidebars;


### PR DESCRIPTION
## Description:

This pull request addresses the issue of adding the necessary paths for the "Becoming a Maintainer" course documentation within the `sidebar.js` file.  It implements the Spanish sidebar configuration, allowing for proper navigation of the translated course content.  This ensures a seamless user experience when accessing the course documentation locally (`http://localhost:3000/learn/becoming-a-maintainer/translations/es/`).

## Related Issue & GitHub Discussions

Closes #14 

## Screenshots

![Screenshot 2025-04-10 22 02 13](https://github.com/user-attachments/assets/e085bcd3-279a-4fa9-87fb-2d83d48ca654)

## Steps to QA

1. `npm start`

2. Open your web browser and navigate to the application's URL(http://localhost:3000/es/learn/becoming-a-maintainer)
